### PR TITLE
added optional 'options' parameter to start/stop

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -84,22 +84,36 @@ module.exports = {
         });
     },
 
-    start: function(units, fn){
+    start: function(units, options, fn){
         if (_.isArray(units))
             units = units.join(" ");
 
-        var sub_command = ["start", units].join(" ");
+        if (_.isArray(options))
+            options = options.join(" ");
+        else if (_.isFunction(options))
+            fn = options, options = "";
+        else if (_.isNull(options))
+            options = "";
+
+        var sub_command = ["start", options, units].join(" ");
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
         });
     },
 
-    stop: function(units, fn){
+    stop: function(units, options, fn){
         if (_.isArray(units))
             units = units.join(" ");
 
-        var sub_command = ["stop", units].join(" ");
+        if (_.isArray(options))
+            options = options.join(" ");
+        else if (_.isFunction(options))
+            fn = options, options = "";
+        else if (_.isNull(options))
+            options = "";
+
+        var sub_command = ["stop", options, units].join(" ");
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);


### PR DESCRIPTION
I've noticed that some units take longer to stop and it may be useful to be able to pass in `--no-block` to the `stop` command if we absolutely need to know that the command was successful. Since `start` takes the same flags, I added the capability to that as well. 

The `options` parameter is optional. All of these examples are valid:

`--no-block` option:

```
var fleetctl = require('fleetctl');
var Fleetctl = new fleetctl({
    binary: 'fleetctl --endpoint=http://192.168.1.100:4001'
});
Fleetctl.stop(units, "--no-block", function (err) {
       // waiting until the unit(s) stops....
});
```

Multiple options:

```
var fleetctl = require('fleetctl');
var Fleetctl = new fleetctl({
    binary: 'fleetctl --endpoint=http://192.168.1.100:4001'
});
Fleetctl.stop(units, ["--no-block=false", "--block-attempts=50"], function (err) {
       // waiting for units to stop, 50 attempts....
});
```

Default options:

```
var fleetctl = require('fleetctl');
var Fleetctl = new fleetctl({
    binary: 'fleetctl --endpoint=http://192.168.1.100:4001'
});
Fleetctl.stop(units, function (err) {
       // this uses the default options:
       // --block-attempts=10
       // --no-block=false
});
```
