### PR TITLE
fixes for fleet 0.8.3 & added tunnel opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ fleetctl.start("unit1", function(err){
 
 **stop**
 ```javascript
-fleetctl.stop("unit1", ["-noblock=true"], function(err){
+fleetctl.stop("unit1", ["-no-block=true"], function(err){
     if(err)
         throw err;
 });

--- a/fleetctl.js
+++ b/fleetctl.js
@@ -7,6 +7,8 @@ function Fleetctl(config){
 
 Fleetctl.prototype.configure = function(config){
     this.binary = config.binary || "fleetctl";
+    if(config.tunnel)
+      this.tunnel = config.tunnel;
 }
 
 _.each(api, function(method, name){

--- a/lib/api.js
+++ b/lib/api.js
@@ -6,6 +6,10 @@ module.exports = {
 
     list_machines: function(fn){
         var sub_command = ["list-machines", "--full", "--no-legend"].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             var machines = [];
@@ -35,6 +39,10 @@ module.exports = {
 
     list_units: function(fn){
         var sub_command = ["list-units", "--full", "--no-legend"].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             var units = [];
@@ -49,20 +57,61 @@ module.exports = {
                         else
                             return value;
                     });
-                    if(parsed.length == 7){
+                    if(parsed.length == 4){
                         var machine = [null, null];
-                        if(!_.isNull(parsed[6]))
-                            machine = parsed[6].split("/");
+                        if(!_.isNull(parsed[1]))
+                            machine = parsed[1].split("/");
 
                         var unit = {
                             unit: parsed[0],
-                            state: parsed[1],
-                            load: parsed[2],
-                            active: parsed[3],
-                            sub: parsed[4],
-                            desc: parsed[5],
-                            machine: machine[0],
-                            ip: machine[1]
+                            machine: parsed[1],
+                            active: parsed[2],
+                            sub: parsed[3],
+                            machineId: machine[0],
+                            machineIp: machine[1]
+                        }
+                        units.push(unit);
+                    }
+                });
+            }
+
+            fn(err, units);
+        });
+    },
+
+    list_unit_files: function(fn){
+        var sub_command = ["list-unit-files", "--full", "--no-legend"].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
+
+        executor.execute(this.binary, sub_command, function(err, response){
+            var units = [];
+
+            if(_.isNull(err)){
+                _.each(response.split("\n"), function(line){
+                    if(_.isEmpty(line))
+                        return;
+                    var parsed = _.map(line.replace(/\t+/g, "\t").split("\t"), function(value){
+                        if(value == "-")
+                            return null;
+                        else
+                            return value;
+                    });
+                    if(parsed.length == 5){
+                        var machine = [null, null];
+                        if(!_.isNull(parsed[4]))
+                            machine = parsed[4].split("/");
+
+                        var unit = {
+                            unit: parsed[0],
+                            hash: parsed[1],
+                            dState: parsed[2],
+                            state: parsed[3],
+                            target: parsed[4],
+                            machineId: machine[0],
+                            machineIp: machine[1]
                         }
                         units.push(unit);
                     }
@@ -78,6 +127,10 @@ module.exports = {
             units = units.join(" ");
 
         var sub_command = ["submit", units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
@@ -96,6 +149,10 @@ module.exports = {
             options = "";
 
         var sub_command = ["load", options, units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
@@ -114,6 +171,10 @@ module.exports = {
             options = "";
 
         var sub_command = ["unload", options, units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
@@ -132,6 +193,10 @@ module.exports = {
             options = "";
 
         var sub_command = ["start", options, units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
@@ -150,6 +215,10 @@ module.exports = {
             options = "";
 
         var sub_command = ["stop", options, units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);
@@ -161,6 +230,10 @@ module.exports = {
             units = units.join(" ");
 
         var sub_command = ["destroy", units].join(" ");
+        if(this.tunnel) {
+            var tunnel = "--tunnel="+this.tunnel+" ";
+            sub_command = tunnel.concat(sub_command);
+        }
 
         executor.execute(this.binary, sub_command, function(err, response){
             fn(err);


### PR DESCRIPTION
Here are some quick changes I've made to make sure this lib works with fleetctl 0.8.3.
- list-units: no longer returns 7 columns. It now returns 4.
- stop: opt -noblock changed to -no-block

New features:
- list-unit-files
- tunnel support (passed via options) I havent updated README.

```
var fleetctl = new Fleetctl({
  binary: "/usr/local/bin/fleetctl"
  tunnel: '127.0.0.1'
});
```
