### PR TITLE
Ignore fleetctl old version warning

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -4,9 +4,8 @@ module.exports = {
 
     execute: function(binary, global_options, sub_command, fn){
         exec([binary, global_options, sub_command].join(" "), function(err, stdout, stderr){
-            if(err || stderr){
-                if(!err)
-                    err = new Error(stderr);
+            if (!err && stderr && stderr.indexOf('WARNING: fleetctl') === -1) {
+                err = new Error(stderr);
             }
 
             fn(err, stdout);


### PR DESCRIPTION
We ran into an issue where the fleet version in one cluster updated to 0.9.1, but another remained on 0.9.0.  The fleetctl warning about different versions caused node-fleetctl to return an error even when everything is "ok".

This PR ignores the fleetctl version mismatch error.
